### PR TITLE
fix README.md action publish has no --diff

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ You can see differences between publishes with following command:
 
   aptly-publisher -v --url http://localhost:8080  \
   --source nightly/trusty --target testing/trusty \
-  publish --diff
+  promote --diff
 
 Example output can look like this:
 


### PR DESCRIPTION
in example to show differences between publishes the action `publish` is used. But only the action `promote` accepts the argument `--diff`