### PR TITLE
Added ability to specify complex prefix

### DIFF
--- a/aptly/publisher/__init__.py
+++ b/aptly/publisher/__init__.py
@@ -156,7 +156,7 @@ class Publish(object):
         dist_split = distribution.split('/')
         self.distribution = dist_split[-1]
         if dist_split[0] != self.distribution:
-            self.prefix = dist_split[0]
+            self.prefix = "_".join(dist_split[:-1])
         else:
             self.prefix = ''
 


### PR DESCRIPTION
If user wants to publish to different folder rather than public.
For example we publishing to repo_name/ubuntu-xenial/stable.
ubuntu-xenial supposed to be part of prefix. So we need concatenate
everything before last slash.

Change-Id: I953c3546159c0d5f008381cc9a0cd04cecc84fb7