### PR TITLE
Keep publishes and snapshots variable to get rid of http requests

### DIFF
--- a/aptly/decorators.py
+++ b/aptly/decorators.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+
+
+class CachedMethod(object):
+    """
+    Decorator for caching of function results
+    """
+    def __init__(self, function):
+        self.function = function
+        self.mem = {}
+
+    def __call__(self, *args, **kwargs):
+        cached = kwargs.pop('cached', True)
+        if cached is True:
+            if (args, str(kwargs)) in self.mem:
+                return self.mem[args, str(kwargs)]
+
+        tmp = self.function(*args, **kwargs)
+        self.mem[args, str(kwargs)] = tmp
+        return tmp
+
+    def __get__(self, obj, objtype):
+        """ Support instance methods """
+        import functools
+        return functools.partial(self.__call__, obj)

--- a/aptly/publisher/__main__.py
+++ b/aptly/publisher/__main__.py
@@ -205,7 +205,7 @@ def find_publishes(client, source, target):
         lg.error("Source publish is regular expression but target does not refer any match groups. See help for more info.")
         sys.exit(1)
     lg.debug("Looking for source publishes matching regular expression: {0}".format(source))
-    publishes = client.do_get('/publish')
+    publishes = Publish._get_publishes(client)
     re_source = re.compile(source)
     for publish in publishes:
         name = "{}{}{}".format(publish['Storage']+":" if publish['Storage']
@@ -308,7 +308,7 @@ def action_publish(client, publishmgr, config_file, recreate=False,
                    only_latest=False, components=[]):
     if not architectures:
         architectures = []
-    snapshots = client.do_get('/snapshots', {'sort': 'time'})
+    snapshots = Publish._get_snapshots(client)
 
     config = load_config(config_file)
     for name, repo in config.get('mirror', {}).items():


### PR DESCRIPTION
The commit gets rid of useless http request which will return the same result.