### PR TITLE
accept underscore('_' ) as additional delimiter for snapshot name

### DIFF
--- a/aptly/publisher/__main__.py
+++ b/aptly/publisher/__main__.py
@@ -25,7 +25,7 @@ def load_config(config):
 
 def get_latest_snapshot(snapshots, name):
     for snapshot in reversed(snapshots):
-        if re.match(r'%s-\d+' % name, snapshot['Name']):
+        if re.match(r'%s[-_]\d+' % name, snapshot['Name']):
             return snapshot['Name']
 
 


### PR DESCRIPTION
I want to use undescores as an delimiter between snapshot name and timestamp