### PR TITLE
support publishing to local repositories/storage

### DIFF
--- a/aptly/publisher/__init__.py
+++ b/aptly/publisher/__init__.py
@@ -245,7 +245,7 @@ class Publish(object):
 
         self.name = '%s/%s' % (self.prefix or '.', self.distribution)
         self.full_name = "{}{}{}".format(self.storage+":" if self.storage else
-                                         "", self.prefix+"/" if self.prefix else
+                                         "/", self.prefix + "/" if self.prefix else
                                          "", self.distribution)
 
         if not timestamp:


### PR DESCRIPTION
at least with aptly 1.4.0+ds1-4+b4 doing a simple `PUT /api/publish/local-repo` or `DELETE /api/publish/local-repo` will result in a 404.

the proper way is to either use a storage specification `:.` or leave it
empty (but keep the slash intact)

Closes: https://github.com/tcpcloud/python-aptly/issues/29