### PR TITLE
Use yaml.safe_load() to fix deprecation and crash

### DIFF
--- a/aptly/publisher/__init__.py
+++ b/aptly/publisher/__init__.py
@@ -13,7 +13,7 @@ lg = logging.getLogger(__name__)
 
 def load_publish(publish):
     with open(publish, 'r') as publish_file:
-        return yaml.load(publish_file)
+        return yaml.safe_load(publish_file)
 
 
 class PublishManager(object):

--- a/aptly/publisher/__main__.py
+++ b/aptly/publisher/__main__.py
@@ -20,7 +20,7 @@ lg = logging.getLogger('aptly-publisher')
 
 def load_config(config):
     with open(config, 'r') as fh:
-        return yaml.load(fh)
+        return yaml.safe_load(fh)
 
 
 def get_latest_snapshot(snapshots, name):


### PR DESCRIPTION
The `yaml.load()` function without a `Loader` keyword is deprecated since `pyyaml 5.1` and removed with `pyyaml 6.0`.

Ubuntu 24.04 noble ships with `pyyaml 6.0.1` breaking `python-aptly` and `aptly-publisher`.

Fix it by using the recommended `yaml.safe_load()` function.

Fixes: https://github.com/tcpcloud/python-aptly/issues/32

Edit: tested against `aptly 1.5.0+162+g8029305d` on Ubuntu 20.04, 22.04, 24.04

Ubuntu 18.04 is broken since https://github.com/tcpcloud/python-aptly/pull/30 (which fixed the newer Ubuntu versions), so for me this is ok

edit: just to be clear, the only thing not working on Ubuntu 18.04 with the newest master branch is `publish --recreate`, just `publish` still works