### PR TITLE
Fix regex warnings by removing extra escapes '\' not needed

### DIFF
--- a/aptly/publisher/__init__.py
+++ b/aptly/publisher/__init__.py
@@ -176,7 +176,7 @@ class PublishManager(object):
         # extract nodes from dot-data
         # list of tuples with (node_id, node_type, node_name)
         # node_type is one of 'Repo'|'Snapshot'|'Publish'
-        nodes_raw = re.findall('[ \t]+"([^"]+)".*label="{(Repo|Snapshot|Published) ([^|]+)[^\}"]+}"', dot_data)
+        nodes_raw = re.findall('[ \t]+"([^"]+)".*label="{(Repo|Snapshot|Published) ([^|]+)[^}"]+}"', dot_data)
 
         # convert nodes_raw into nodes
         # nodes = dict of node_id to node
@@ -588,7 +588,7 @@ class Publish(object):
         """
         if not ref:
             return None
-        parsed = re.match('(.*)\ (.*)\ (.*)\ (.*)', ref)
+        parsed = re.match('(.*) (.*) (.*) (.*)', ref)
         return parsed.groups()
 
     def add(self, snapshot, component='main'):


### PR DESCRIPTION
On Ubuntu 24.04 with Python 3.12 two regexes showed the warning about invalid escape sequences:

```
aptly/publisher/__init__.py:179: SyntaxWarning: invalid escape sequence '\}'
  nodes_raw = re.findall('[ \t]+"([^"]+)".*label="{(Repo|Snapshot|Published) ([^|]+)[^\}"]+}"', dot_data)
aptly/publisher/__init__.py:591: SyntaxWarning: invalid escape sequence '\ '
  parsed = re.match('(.*)\ (.*)\ (.*)\ (.*)', ref)
```

Fix those regexes by removing the not needed escapes `\`.
- the `}` inside the `[]` grouping doesn't need to be escaped
  - from: https://docs.python.org/3/howto/regex.html#matching-characters
  - Metacharacters (except `\`) are not active inside classes. For example, `[akm$]` will match any of the characters 'a', 'k', 'm', or '$'; '$' is usually a metacharacter, but inside a character class it’s stripped of its special nature.
- the space character ` ` doesn't need to be escaped

Tested on Ubuntu 18.04, 20.04, 22.04 and 24.04 with the `cleanup` command (which uses the first regex) and the `dump` command (which uses the second regex)

```sh
python3 -m aptly.publisher -v --url http://example.com/aptly cleanup
python3 -m aptly.publisher -v --url http://example.com/aptly dump --publish "all"
```

Fixes: https://github.com/tcpcloud/python-aptly/issues/33